### PR TITLE
Handle case where fees are not computed at charge time

### DIFF
--- a/pinpayments/models.py
+++ b/pinpayments/models.py
@@ -278,7 +278,7 @@ class PinTransaction(models.Model):
             data = response_json['response']
             self.succeeded = True
             self.transaction_token = data['token']
-            self.fees = data['total_fees'] / Decimal("100.00")
+            self.fees = data['total_fees'] / Decimal("100.00") if data['total_fees'] is not None else None
             self.pin_response = data['status_message']
             self.card_address1 = data['card']['address_line1']
             self.card_address2 = data['card']['address_line2']


### PR DESCRIPTION
When charging in a currency that is not the settlement currency, the fees are not computed at the time of the charge. My tests were done using USD and settling in AUD.

This does not appear in Pin's documentation, so I reached out to them to confirm:

> The reason for this is that our fees aren't calculated until the USD to AUD currency conversion has occurred, which is typically after 3 business days. This doesn't happen with AUD charges as the funds are already in AUD and we can calculate the appropriate fees.

The patch deals with this situation.

Sample request:
```
> curl https://test-api.pinpayments.com/1/charges -u SNIP: \
                        -d "amount=6211" \
                        -d "currency=USD" \
                        -d "description=test charge" \
                        -d "email=fred@example.com" \
                        -d "ip_address=203.192.1.172" \
                        -d "card[number]=5520000000000000" \
                        -d "card[expiry_month]=05" \
                        -d "card[expiry_year]=2019" \
                        -d "card[cvc]=123" \
                        -d "card[name]=Roland Robot" \
                        -d "card[address_line1]=42 Sevenoaks St" \
                        -d "card[address_line2]=" \
                        -d "card[address_city]=Lathlain" \
                        -d "card[address_postcode]=6454" \
                        -d "card[address_state]=WA" \
                        -d "card[address_country]=AR" \
                        -d "metadata[OrderNumber]=123456" \
                        -d "metadata[CustomerName]=Roland Robot" | python -m json.tool

{
    "response": {
        "active_chargebacks": false,
        "amount": 6211,
        "amount_refunded": 0,
        "authorisation_expired": false,
        "captured": true,
        "captured_at": "2018-11-21T03:47:31Z",
        "card": {
            "address_city": "Lathlain",
            "address_country": "AR",
            "address_line1": "42 Sevenoaks St",
            "address_line2": "",
            "address_postcode": "6454",
            "address_state": "WA",
            "customer_token": null,
            "display_number": "XXXX-XXXX-XXXX-0000",
            "expiry_month": 5,
            "expiry_year": 2019,
            "issuing_country": "AU",
            "name": "Roland Robot",
            "primary": null,
            "scheme": "master",
            "token": "card_zURL6tjTTmdkweyHalRtug"
        },
        "created_at": "2018-11-21T03:47:31Z",
        "currency": "USD",
        "description": "test charge",
        "email": "fred@example.com",
        "error_message": null,
        "ip_address": "203.192.1.172",
        "merchant_entitlement": null,
        "metadata": {
            "customername": "Roland Robot",
            "ordernumber": "123456"
        },
        "refund_pending": false,
        "settlement_currency": "AUD",
        "status_message": "Success",
        "success": true,
        "token": "ch_lcVTRFXCJKh1wk0BX-Btlw",
        "total_fees": null,
        "transfer": []
    }
}
```
