### PR TITLE
docs: Fix simple typo, paramater -> parameter

### DIFF
--- a/pinpayments/templatetags/pin_payment_tags.py
+++ b/pinpayments/templatetags/pin_payment_tags.py
@@ -9,7 +9,7 @@ def pin_header(context, environment=''):
     """
     pin_header - Renders the JavaScript required for Pin.js payments.
     This will also include the Pin.js file from pin.net.au.
-    Optionally accepts an 'environment' (eg test/live) as a paramater,
+    Optionally accepts an 'environment' (eg test/live) as a parameter,
     otherwise the default will be used.
     """
     if environment == '':


### PR DESCRIPTION
There is a small typo in pinpayments/templatetags/pin_payment_tags.py.

Should read `parameter` rather than `paramater`.

